### PR TITLE
Fixed typographical error, changed aganist to against in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ filters by **default**. You can filter requests using three different
 methods:
 
 1. Symbols (treated as file extensions)
-2. Regex (matched aganist the full URL)
+2. Regex (matched against the full URL)
 3. Blocks/Procs/Lambda/Things that `respond_to? :call`
 
 Filters are used to exclude requests. So, if a filter returns true then


### PR DESCRIPTION
@ahawkins, I've corrected a typographical error in the documentation of the [http_log](https://github.com/ahawkins/http_log) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
